### PR TITLE
Eng privacy policy terms

### DIFF
--- a/docs/privacy_policy/en.html
+++ b/docs/privacy_policy/en.html
@@ -1,0 +1,110 @@
+<!DOCTYPE html>
+    <html>
+    <head>
+      <meta charset='utf-8'>
+      <meta name='viewport' content='width=device-width'>
+      <title>Privacy Policy</title>
+      <style> body { font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; padding:1em; } </style>
+    </head>
+    <body>
+    <strong>Privacy Policy</strong> <p>
+                  Olena Yanishevska, Igor Ianishevskyi built the My Horoscope app as
+                  an Ad Supported app. This SERVICE is provided by
+                  Olena Yanishevska at no cost and is intended for use as
+                  is.
+                </p> <p>
+                  This page is used to inform visitors regarding my
+                  policies with the collection, use, and disclosure of Personal
+                  Information if anyone decided to use my Service.
+                </p> <p>
+                  If you choose to use my Service, then you agree to
+                  the collection and use of information in relation to this
+                  policy. The Personal Information that I collect is
+                  used for providing and improving the Service. I will not use or share your information with
+                  anyone except as described in this Privacy Policy.
+                </p> <p>
+                  The terms used in this Privacy Policy have the same meanings
+                  as in our Terms and Conditions, which is accessible at
+                  My Horoscope unless otherwise defined in this Privacy Policy.
+                </p> <p><strong>Information Collection and Use</strong></p> <p>
+                  For a better experience, while using our Service, I
+                  may require you to provide us with certain personally
+                  identifiable information, including but not limited to advertising ID, IP address. The information that
+                  I request will be retained on your device and is not collected by me in any way.
+                </p> <div><p>
+                    The app does use third party services that may collect
+                    information used to identify you.
+                  </p> <p>
+                    Link to privacy policy of third party service providers used
+                    by the app
+                  </p> <ul><li><a href="https://www.google.com/policies/privacy/" target="_blank" rel="noopener noreferrer">Google Play Services</a></li><!----><li><a href="https://firebase.google.com/policies/analytics" target="_blank" rel="noopener noreferrer">Google Analytics for Firebase</a></li><li><a href="https://firebase.google.com/support/privacy/" target="_blank" rel="noopener noreferrer">Firebase Crashlytics</a></li><!----><!----><!----><!----><!----><li><a href="https://www.appodeal.com/home/privacy-policy/" target="_blank" rel="noopener noreferrer">Appodeal</a></li><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----></ul></div> <p><strong>Log Data</strong></p> <p>
+                  I want to inform you that whenever you
+                  use my Service, in a case of an error in the app
+                  I collect data and information (through third party
+                  products) on your phone called Log Data. This Log Data may
+                  include information such as your device Internet Protocol
+                  (“IP”) address, device name, operating system version, the
+                  configuration of the app when utilizing my Service,
+                  the time and date of your use of the Service, and other
+                  statistics.
+                </p> <p><strong>Cookies</strong></p> <p>
+                  Cookies are files with a small amount of data that are
+                  commonly used as anonymous unique identifiers. These are sent
+                  to your browser from the websites that you visit and are
+                  stored on your device's internal memory.
+                </p> <p>
+                  This Service does not use these “cookies” explicitly. However,
+                  the app may use third party code and libraries that use
+                  “cookies” to collect information and improve their services.
+                  You have the option to either accept or refuse these cookies
+                  and know when a cookie is being sent to your device. If you
+                  choose to refuse our cookies, you may not be able to use some
+                  portions of this Service.
+                </p> <p><strong>Service Providers</strong></p> <p>
+                  I may employ third-party companies and
+                  individuals due to the following reasons:
+                </p> <ul><li>To facilitate our Service;</li> <li>To provide the Service on our behalf;</li> <li>To perform Service-related services; or</li> <li>To assist us in analyzing how our Service is used.</li></ul> <p>
+                  I want to inform users of this Service
+                  that these third parties have access to your Personal
+                  Information. The reason is to perform the tasks assigned to
+                  them on our behalf. However, they are obligated not to
+                  disclose or use the information for any other purpose.
+                </p> <p><strong>Security</strong></p> <p>
+                  I value your trust in providing us your
+                  Personal Information, thus we are striving to use commercially
+                  acceptable means of protecting it. But remember that no method
+                  of transmission over the internet, or method of electronic
+                  storage is 100% secure and reliable, and I cannot
+                  guarantee its absolute security.
+                </p> <p><strong>Links to Other Sites</strong></p> <p>
+                  This Service may contain links to other sites. If you click on
+                  a third-party link, you will be directed to that site. Note
+                  that these external sites are not operated by me.
+                  Therefore, I strongly advise you to review the
+                  Privacy Policy of these websites. I have
+                  no control over and assume no responsibility for the content,
+                  privacy policies, or practices of any third-party sites or
+                  services.
+                </p> <p><strong>Children’s Privacy</strong></p> <p>
+                  These Services do not address anyone under the age of 13.
+                  I do not knowingly collect personally
+                  identifiable information from children under 13 years of age. In the case
+                  I discover that a child under 13 has provided
+                  me with personal information, I immediately
+                  delete this from our servers. If you are a parent or guardian
+                  and you are aware that your child has provided us with
+                  personal information, please contact me so that
+                  I will be able to do necessary actions.
+                </p> <p><strong>Changes to This Privacy Policy</strong></p> <p>
+                  I may update our Privacy Policy from
+                  time to time. Thus, you are advised to review this page
+                  periodically for any changes. I will
+                  notify you of any changes by posting the new Privacy Policy on
+                  this page.
+                </p> <p>This policy is effective as of 2021-09-17</p> <p><strong>Contact Us</strong></p> <p>
+                  If you have any questions or suggestions about my
+                  Privacy Policy, do not hesitate to contact me at myhoroskopeapp@gmail.com.
+                </p> <p>This privacy policy page was created at <a href="https://privacypolicytemplate.net" target="_blank" rel="noopener noreferrer">privacypolicytemplate.net </a>and modified/generated by <a href="https://app-privacy-policy-generator.nisrulz.com/" target="_blank" rel="noopener noreferrer">App Privacy Policy Generator</a></p>
+    </body>
+    </html>
+      

--- a/docs/privacy_policy/en.html
+++ b/docs/privacy_policy/en.html
@@ -10,7 +10,7 @@
     <strong>Privacy Policy</strong> <p>
                   Olena Yanishevska, Igor Ianishevskyi built the My Horoscope app as
                   an Ad Supported app. This SERVICE is provided by
-                  Olena Yanishevska at no cost and is intended for use as
+                  Olena Yanishevska, Igor Ianishevskyi at no cost and is intended for use as
                   is.
                 </p> <p>
                   This page is used to inform visitors regarding my
@@ -29,7 +29,7 @@
                 </p> <p><strong>Information Collection and Use</strong></p> <p>
                   For a better experience, while using our Service, I
                   may require you to provide us with certain personally
-                  identifiable information, including but not limited to advertising ID, IP address. The information that
+                  identifiable information, including but not limited to advertising ID, IP address, name, birth date, gender. The information that
                   I request will be retained on your device and is not collected by me in any way.
                 </p> <div><p>
                     The app does use third party services that may collect

--- a/docs/user_agreement/en.html
+++ b/docs/user_agreement/en.html
@@ -17,9 +17,9 @@
                   to translate the app into other languages, or make derivative
                   versions. The app itself, and all the trade marks, copyright,
                   database rights and other intellectual property rights related
-                  to it, still belong to Olena Yanishevska.
+                  to it, still belong to Olena Yanishevska, Igor Ianishevskyi.
                 </p> <p>
-                  Olena Yanishevska and Igor Ianishevskyi are committed to ensuring that the app is
+                  Olena Yanishevska, Igor Ianishevskyi is committed to ensuring that the app is
                   as useful and efficient as possible. For that reason, we
                   reserve the right to make changes to the app or to charge for
                   its services, at any time and for any reason. We will never
@@ -44,10 +44,10 @@
                     providers used by the app
                   </p> <ul><li><a href="https://policies.google.com/terms" target="_blank" rel="noopener noreferrer">Google Play Services</a></li><!----><li><a href="https://firebase.google.com/terms/analytics" target="_blank" rel="noopener noreferrer">Google Analytics for Firebase</a></li><li><a href="https://firebase.google.com/terms/crashlytics" target="_blank" rel="noopener noreferrer">Firebase Crashlytics</a></li><!----><!----><!----><!----><!----><li><a href="https://www.appodeal.com/home/terms-of-service/" target="_blank" rel="noopener noreferrer">Appodeal</a></li><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----></ul></div> <p>
                   You should be aware that there are certain things that
-                  Olena Yanishevska will not take responsibility for. Certain
+                  Olena Yanishevska, Igor Ianishevskyi will not take responsibility for. Certain
                   functions of the app will require the app to have an active
                   internet connection. The connection can be Wi-Fi, or provided
-                  by your mobile network provider, but Olena Yanishevska
+                  by your mobile network provider, but Olena Yanishevska, Igor Ianishevskyi
                   cannot take responsibility for the app not working at full
                   functionality if you don’t have access to Wi-Fi, and you don’t
                   have any of your data allowance left.
@@ -65,18 +65,18 @@
                   using the app, please be aware that we assume that you have
                   received permission from the bill payer for using the app.
                 </p> <p>
-                  Along the same lines, Olena Yanishevska cannot always take
+                  Along the same lines, Olena Yanishevska, Igor Ianishevskyi cannot always take
                   responsibility for the way you use the app i.e. You need to
                   make sure that your device stays charged – if it runs out of
                   battery and you can’t turn it on to avail the Service,
-                  Olena Yanishevska cannot accept responsibility.
+                  Olena Yanishevska, Igor Ianishevskyi cannot accept responsibility.
                 </p> <p>
-                  With respect to Olena Yanishevska’s responsibility for your
+                  With respect to Olena Yanishevska, Igor Ianishevskyi’s responsibility for your
                   use of the app, when you’re using the app, it’s important to
                   bear in mind that although we endeavour to ensure that it is
                   updated and correct at all times, we do rely on third parties
                   to provide information to us so that we can make it available
-                  to you. Olena Yanishevska accepts no liability for any
+                  to you. Olena Yanishevska, Igor Ianishevskyi accepts no liability for any
                   loss, direct or indirect, you experience as a result of
                   relying wholly on this functionality of the app.
                 </p> <p>
@@ -85,7 +85,7 @@
                   both systems(and for any additional systems we
                   decide to extend the availability of the app to) may change,
                   and you’ll need to download the updates if you want to keep
-                  using the app. Olena Yanishevska does not promise that it
+                  using the app. Olena Yanishevska, Igor Ianishevskyi does not promise that it
                   will always update the app so that it is relevant to you
                   and/or works with the Android &amp; iOS version that you have
                   installed on your device. However, you promise to always

--- a/docs/user_agreement/en.html
+++ b/docs/user_agreement/en.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+    <html>
+    <head>
+      <meta charset='utf-8'>
+      <meta name='viewport' content='width=device-width'>
+      <title>Terms &amp; Conditions</title>
+      <style> body { font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; padding:1em; } </style>
+    </head>
+    <body>
+    <strong>Terms &amp; Conditions</strong> <p>
+                  By downloading or using the app, these terms will
+                  automatically apply to you – you should make sure therefore
+                  that you read them carefully before using the app. You’re not
+                  allowed to copy, or modify the app, any part of the app, or
+                  our trademarks in any way. You’re not allowed to attempt to
+                  extract the source code of the app, and you also shouldn’t try
+                  to translate the app into other languages, or make derivative
+                  versions. The app itself, and all the trade marks, copyright,
+                  database rights and other intellectual property rights related
+                  to it, still belong to Olena Yanishevska.
+                </p> <p>
+                  Olena Yanishevska and Igor Ianishevskyi are committed to ensuring that the app is
+                  as useful and efficient as possible. For that reason, we
+                  reserve the right to make changes to the app or to charge for
+                  its services, at any time and for any reason. We will never
+                  charge you for the app or its services without making it very
+                  clear to you exactly what you’re paying for.
+                </p> <p>
+                  The My Horoscope app stores and processes personal data that
+                  you have provided to us, in order to provide my
+                  Service. It’s your responsibility to keep your phone and
+                  access to the app secure. We therefore recommend that you do
+                  not jailbreak or root your phone, which is the process of
+                  removing software restrictions and limitations imposed by the
+                  official operating system of your device. It could make your
+                  phone vulnerable to malware/viruses/malicious programs,
+                  compromise your phone’s security features and it could mean
+                  that the My Horoscope app won’t work properly or at all.
+                </p> <div><p>
+                    The app does use third party services that declare their own
+                    Terms and Conditions.
+                  </p> <p>
+                    Link to Terms and Conditions of third party service
+                    providers used by the app
+                  </p> <ul><li><a href="https://policies.google.com/terms" target="_blank" rel="noopener noreferrer">Google Play Services</a></li><!----><li><a href="https://firebase.google.com/terms/analytics" target="_blank" rel="noopener noreferrer">Google Analytics for Firebase</a></li><li><a href="https://firebase.google.com/terms/crashlytics" target="_blank" rel="noopener noreferrer">Firebase Crashlytics</a></li><!----><!----><!----><!----><!----><li><a href="https://www.appodeal.com/home/terms-of-service/" target="_blank" rel="noopener noreferrer">Appodeal</a></li><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----><!----></ul></div> <p>
+                  You should be aware that there are certain things that
+                  Olena Yanishevska will not take responsibility for. Certain
+                  functions of the app will require the app to have an active
+                  internet connection. The connection can be Wi-Fi, or provided
+                  by your mobile network provider, but Olena Yanishevska
+                  cannot take responsibility for the app not working at full
+                  functionality if you don’t have access to Wi-Fi, and you don’t
+                  have any of your data allowance left.
+                </p> <p></p> <p>
+                  If you’re using the app outside of an area with Wi-Fi, you
+                  should remember that your terms of the agreement with your
+                  mobile network provider will still apply. As a result, you may
+                  be charged by your mobile provider for the cost of data for
+                  the duration of the connection while accessing the app, or
+                  other third party charges. In using the app, you’re accepting
+                  responsibility for any such charges, including roaming data
+                  charges if you use the app outside of your home territory
+                  (i.e. region or country) without turning off data roaming. If
+                  you are not the bill payer for the device on which you’re
+                  using the app, please be aware that we assume that you have
+                  received permission from the bill payer for using the app.
+                </p> <p>
+                  Along the same lines, Olena Yanishevska cannot always take
+                  responsibility for the way you use the app i.e. You need to
+                  make sure that your device stays charged – if it runs out of
+                  battery and you can’t turn it on to avail the Service,
+                  Olena Yanishevska cannot accept responsibility.
+                </p> <p>
+                  With respect to Olena Yanishevska’s responsibility for your
+                  use of the app, when you’re using the app, it’s important to
+                  bear in mind that although we endeavour to ensure that it is
+                  updated and correct at all times, we do rely on third parties
+                  to provide information to us so that we can make it available
+                  to you. Olena Yanishevska accepts no liability for any
+                  loss, direct or indirect, you experience as a result of
+                  relying wholly on this functionality of the app.
+                </p> <p>
+                  At some point, we may wish to update the app. The app is
+                  currently available on Android &amp; iOS – the requirements for
+                  both systems(and for any additional systems we
+                  decide to extend the availability of the app to) may change,
+                  and you’ll need to download the updates if you want to keep
+                  using the app. Olena Yanishevska does not promise that it
+                  will always update the app so that it is relevant to you
+                  and/or works with the Android &amp; iOS version that you have
+                  installed on your device. However, you promise to always
+                  accept updates to the application when offered to you, We may
+                  also wish to stop providing the app, and may terminate use of
+                  it at any time without giving notice of termination to you.
+                  Unless we tell you otherwise, upon any termination, (a) the
+                  rights and licenses granted to you in these terms will end;
+                  (b) you must stop using the app, and (if needed) delete it
+                  from your device.
+                </p> <p><strong>Changes to This Terms and Conditions</strong></p> <p>
+                  I may update our Terms and Conditions
+                  from time to time. Thus, you are advised to review this page
+                  periodically for any changes. I will
+                  notify you of any changes by posting the new Terms and
+                  Conditions on this page.
+                </p> <p>
+                  These terms and conditions are effective as of 2021-09-17
+                </p> <p><strong>Contact Us</strong></p> <p>
+                  If you have any questions or suggestions about my
+                  Terms and Conditions, do not hesitate to contact me
+                  at myhoroskopeapp@gmail.com.
+                </p> <p>This Terms and Conditions page was generated by <a href="https://app-privacy-policy-generator.nisrulz.com/" target="_blank" rel="noopener noreferrer">App Privacy Policy Generator</a></p>
+    </body>
+    </html>
+      

--- a/packages/algorithm/pubspec.lock
+++ b/packages/algorithm/pubspec.lock
@@ -187,7 +187,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.7.0"
   mime:
     dependency: transitive
     description:

--- a/packages/base/lib/preferences/interface.dart
+++ b/packages/base/lib/preferences/interface.dart
@@ -1,3 +1,4 @@
+import 'package:base/preferences/setting/locale/utils.dart';
 import 'package:json_annotation/json_annotation.dart';
 
 /// @settings
@@ -17,7 +18,8 @@ class AppPreferencesDat {
   AppPreferencesDat({this.ep, this.locale, this.notifications}) {
     /// @settings
     if (ep == null) ep = EnabledProphecies();
-    if (locale == null) locale = LocaleSettings();
+    if (locale == null)
+      locale = LocaleSettings(language: guessLocaleFromSystem());
     if (notifications == null) notifications = NotificationsPreferences();
   }
 

--- a/packages/base/lib/preferences/setting/locale/utils.dart
+++ b/packages/base/lib/preferences/setting/locale/utils.dart
@@ -1,0 +1,23 @@
+import 'dart:io' show Platform;
+
+String guessLocaleFromSystem() {
+  final languageCode = Platform.localeName.split('_')[0];
+
+  switch (languageCode) {
+    case "ru":
+    case "be":
+    case "kk":
+    case "ky":
+    case "tg":
+    case "uz":
+    case "ce":
+    case "ab":
+    case "ro":
+    case "uk":
+      return "ru";
+
+    case "en":
+    default:
+      return "en";
+  }
+}

--- a/packages/base/pubspec.lock
+++ b/packages/base/pubspec.lock
@@ -264,7 +264,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.7.0"
   mime:
     dependency: transitive
     description:

--- a/packages/mobile_app/lib/common/accept_terms_text.dart
+++ b/packages/mobile_app/lib/common/accept_terms_text.dart
@@ -1,13 +1,10 @@
-import 'package:my_horoskope/theme/app_text_style.dart';
-import 'package:my_horoskope/theme/app_colors.dart';
-import 'package:url_launcher/url_launcher.dart';
 import 'package:flutter/material.dart';
+import 'package:my_horoskope/theme/app_colors.dart';
+import 'package:my_horoskope/theme/app_text_style.dart';
+import 'package:url_launcher/url_launcher.dart';
 
-const _temp = "ru";
-const URL_PRIVACY_POLICY =
-    "https://rimmer.github.io/My-Horoskope/privacy_policy/$_temp.html";
-const URL_USER_AGREEMENT =
-    "https://rimmer.github.io/My-Horoskope/user_agreement/$_temp.html";
+const URL_PRIVACY_POLICY = "https://myhoroskope.app/privacy_policy/:lang.html";
+const URL_USER_AGREEMENT = "https://myhoroskope.app/user_agreement/:lang.html";
 
 class AcceptTermsText extends StatelessWidget {
   final String text;
@@ -31,13 +28,15 @@ class AcceptTermsText extends StatelessWidget {
 class TermsText extends StatelessWidget {
   final String text;
   final String url;
+  final String lang;
 
-  const TermsText({@required this.text, @required this.url});
+  const TermsText(
+      {@required this.text, @required this.url, @required this.lang});
 
   @override
   Widget build(BuildContext context) {
     return TextButton(
-      onPressed: () => launch(url),
+      onPressed: () => launch(url.replaceFirst(":lang", lang)),
       child: Text(
         text,
         style: AppTextStyle.termsText,

--- a/packages/mobile_app/lib/common/language_picker.dart
+++ b/packages/mobile_app/lib/common/language_picker.dart
@@ -67,7 +67,7 @@ class _LanguageChoise extends StatelessWidget {
     @required this.languageName,
   });
 
-  _languageChoise(BuildContext context) async {
+  _languageChoice(BuildContext context) async {
     AppGlobal.data.appPref.locale = LocaleSettings(language: languageCode);
 
     await chooseLocale();
@@ -83,7 +83,7 @@ class _LanguageChoise extends StatelessWidget {
   Widget build(BuildContext context) {
     return TextButton(
       onPressed: () {
-        _languageChoise(context);
+        _languageChoice(context);
       },
       child: Text(
         languageName,

--- a/packages/mobile_app/lib/logic/localization/locale.dart
+++ b/packages/mobile_app/lib/logic/localization/locale.dart
@@ -1,13 +1,8 @@
-import 'dart:io' show Platform;
 import 'package:my_horoskope/app_global.dart';
 import 'package:text/text.dart';
 
 Future chooseLocale() async {
-  var languageCode;
-  if (AppGlobal.data.appPref.dat.locale.language != "none")
-    languageCode = AppGlobal.data.appPref.locale.language;
-  else
-    languageCode = Platform.localeName.split('_')[0];
+  var languageCode = AppGlobal.data.appPref.locale.language;
 
   switch (languageCode) {
     case "ru":

--- a/packages/mobile_app/lib/screens/menu/menu_screen.dart
+++ b/packages/mobile_app/lib/screens/menu/menu_screen.dart
@@ -102,12 +102,14 @@ class MenuScreen extends StatelessWidget {
                         child: TermsText(
                           text: localeText.userAgreement.capitalize(),
                           url: URL_USER_AGREEMENT,
+                          lang: AppGlobal.data.appPref.locale.language,
                         ),
                       ),
                       Flexible(
                         child: TermsText(
                           text: localeText.privacyPolicy.capitalize(),
                           url: URL_PRIVACY_POLICY,
+                          lang: AppGlobal.data.appPref.locale.language,
                         ),
                       ),
                     ],

--- a/packages/mobile_app/pubspec.lock
+++ b/packages/mobile_app/pubspec.lock
@@ -353,7 +353,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.7.0"
   mutable_wrappers:
     dependency: "direct main"
     description:

--- a/packages/symbol/pubspec.lock
+++ b/packages/symbol/pubspec.lock
@@ -14,7 +14,7 @@ packages:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.1"
+    version: "1.7.2"
   args:
     dependency: transitive
     description:
@@ -194,7 +194,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.7.0"
   mime:
     dependency: transitive
     description:


### PR DESCRIPTION
Choosing the right url with locale when open privacy policy or terms

Privacy policy and terms and conditions links are published as github pages and have the following template: `https://myhoroskope.app/privacy_policy/:lang.html`.
For instance, for English, it would be `https://myhoroskope.app/privacy_policy/en.html`

So, in order to choose the right policy, we need to provide the right locate identifier.