### PR TITLE
Fixed: when upgrade from older version still opens wrong url

### DIFF
--- a/packages/base/lib/preferences/setting/locale/item.dart
+++ b/packages/base/lib/preferences/setting/locale/item.dart
@@ -1,3 +1,4 @@
+import 'package:base/preferences/setting/locale/utils.dart';
 import 'package:json_annotation/json_annotation.dart';
 import 'package:meta/meta.dart';
 
@@ -12,6 +13,13 @@ class LocaleSettings {
 
   Map<String, Object> toJson() => _$LocaleSettingsToJson(this);
 
-  static LocaleSettings fromJson(Map<String, Object> json) =>
-      _$LocaleSettingsFromJson(json);
+  static LocaleSettings fromJson(Map<String, Object> json) {
+    var locale = _$LocaleSettingsFromJson(json);
+    // this is for upgrade from older versions
+    // we set locale if "none" had been save priorly
+    if (locale.language == "none") {
+      locale = LocaleSettings(language: guessLocaleFromSystem());
+    }
+    return locale;
+  }
 }

--- a/packages/mobile_app/lib/logic/localization/locale.dart
+++ b/packages/mobile_app/lib/logic/localization/locale.dart
@@ -2,26 +2,13 @@ import 'package:my_horoskope/app_global.dart';
 import 'package:text/text.dart';
 
 Future chooseLocale() async {
-  var languageCode = AppGlobal.data.appPref.locale.language;
-
-  switch (languageCode) {
-    case "ru":
-    case "be":
-    case "kk":
-    case "ky":
-    case "tg":
-    case "uz":
-    case "ce":
-    case "ab":
-    case "ro":
-    case "uk":
-      localeText.switchLocaleToRussian();
-      break;
-
-    case "en":
-    default:
-      localeText.switchLocaleToEnglish();
-      break;
+  // the right locale has already been set during cal to `guessLocaleFromSystem`
+  // hence here we have only "filtered" locales
+  // currently its only `ru` and `en`, which is the default one
+  if (AppGlobal.data.appPref.locale.language == "ru") {
+    localeText.switchLocaleToRussian();
+  } else {
+    localeText.switchLocaleToEnglish();
   }
 
   AppGlobal.data.predictions.jobSync("clear", null);


### PR DESCRIPTION
This commit fixes the bug with updates from older versions of the app, where the "none" locale is stored.