### PR TITLE
Appodeal integration and user ads consent

### DIFF
--- a/docs/app-ads.txt
+++ b/docs/app-ads.txt
@@ -1,1 +1,643 @@
-google.com, pub-6881469170510700, DIRECT, f08c47fec0942fa0
+#Last updated May 12, 2021
+#Appodeal
+appodeal.com, 134304, DIRECT
+#BidMachine
+bidmachine.io, 134304, DIRECT
+#AdMob
+#Copy Admob's app-ads.txt entry from your Admob dashboard
+#Facebook
+#Replace the Business ID below with your Facebook Business ID
+facebook.com, Business ID, RESELLER, c3e20eee3f780d68
+#AdColony
+adcolony.com, fcaa373cac67c9f927aa914013b8346e, RESELLER, 1ad675c9de6b5176
+#Applovin
+applovin.com,c8802c2788bab3703acc24cf065d5390,RESELLER
+applovin.com,5c72b49c2b2ce6949bf0f98eafe9e417,RESELLER
+applovin.com,0b8086e03d0f715f09a9e6e5dbdbb4b8,RESELLER
+applovin.com,94bf1c89704c8e6a46341999e25b1b90,RESELLER
+#InMobi
+inmobi.com, fafa1521dbdb43f69b1eb199a0b007fd, RESELLER, 83e75a7ae333ca9d
+rubiconproject.com, 11726, RESELLER, 0bfd66d529a55807
+rubiconproject.com, 12266, RESELLER, 0bfd66d529a55807
+indexexchange.com, 184738, RESELLER
+openx.com, 537124160, RESELLER, 6a698e2ec38604c6
+openx.com, 539214772, RESELLER, 6a698e2ec38604c6
+smartadserver.com,3232,RESELLER
+pubmatic.com, 157097, RESELLER, 5d62403b186f2ace
+pubmatic.com, 156931, RESELLER, 5d62403b186f2ace
+pubmatic.com, 157153, RESELLER, 5d62403b186f2ace
+xad.com, 767, RESELLER, 81cbf0a75a5e0e9a
+xad.com, 1190, RESELLER, 81cbf0a75a5e0e9a
+verve.com, 5897, RESELLER, 0c8f5958fc2d6270
+rubiconproject.com, 15278, RESELLER, 0bfd66d529a55807
+pubmatic.com, 156517, RESELLER, 5d62403b186f2ace
+EMXDGT.com, 594, RESELLER, 1e1d41537f7cad7f
+appnexus.com, 1356, RESELLER, f5ab79cb980f11d1
+rubiconproject.com,16928, RESELLER, 0bfd66d529a55807
+Blis.com, 33, RESELLER, 61453ae19a4b73f4
+#Amazon
+aps.amazon.com, 13476152, DIRECT
+aps.amazon.com, 13277230, DIRECT
+aps.amazon.com, 15083519, DIRECT
+aps.amazon.com, 15323246, DIRECT
+#IronSource
+ironsrc.com, 186063, RESELLER, 79929e88b2ba73bc
+ironsrc.com, 228853, RESELLER, 79929e88b2ba73bc
+ironsrc.com, 245431, RESELLER, 79929e88b2ba73bc
+ironsrc.com, 220701, RESELLER, 79929e88b2ba73bc
+ironsrc.com, 231453, RESELLER, 79929e88b2ba73bc
+advertising.com, 8693, RESELLER
+aol.com, 25910, RESELLER
+appnexus.com, 2234, RESELLER,
+appnexus.com, 2480, RESELLER,
+axonix.com, 56411, RESELLER
+improvedigital.com, 1114, RESELLER
+inmobi.com, 3af76ebd8ed44d04b01d827c6f3bb5b4 , RESELLER, 83e75a7ae333ca9d
+loopme.com, 10287, RESELLER, 6c8d5f95897a5a3b
+loopme.com, s-2411, RESELLER, 6c8d5f95897a5a3b
+openx.com, 537153564, RESELLER, 6a698e2ec38604c6
+openx.com, 539363588, RESELLER, 6a698e2ec38604c6
+pokkt.com, 5536, RESELLER, c45702d9311e25fd
+rhythmone.com, 3169196794, RESELLER, a670c89d4a324e47
+rubiconproject.com, 15526, RESELLER, 0bfd66d529a55807
+rubiconproject.com, 20942, RESELLER, 0bfd66d529a55807
+smaato.com, 1100004890, RESELLER, 07bcf65f187117b4
+smaato.com, 1100040398, RESELLER, 07bcf65f187117b4
+Smartclip.net, 6740, RESELLER
+smartstream.tv,3199,RESELLER
+smartstream.tv,5641,RESELLER
+spotx.tv, 139784, RESELLER, 7842df1d2fe2db34
+spotxchange.com, 139784, RESELLER, 7842df1d2fe2db34
+telaria.com, 7wy0w, RESELLER, 1a4e959a1b50034a
+tremorhub.com, 7wy0w, RESELLER, 1a4e959a1b50034a
+undertone.com, 3635, RESELLER
+indexexchange.com, 185996, Reseller
+#Mintegral
+mintegral.com, 11154, RESELLER
+#Ogury
+ogury.com, a5021c3244aa371a2a625c7fef071d09, DIRECT
+ogury.com, 8ea3e9ad6c0d6f2abfb6d3d202f846b9,RESELLER
+appnexus.com, 11470, RESELLER
+adcolony.com, e0355e23aa56b4c34dacf5ece1c237bc, RESELLER, 1ad675c9de6b5176
+adcolony.com, 18a97784127f9bb1ce5ca7a0ac39e526 , RESELLER, 1ad675c9de6b5176
+applovin.com, 5a7f80d6d508c0ebe7007ddb1c4cd8b1, RESELLER
+adcolony.com, 5d8cbf6671c93a42, RESELLER, 1ad675c9de6b5176
+rubiconproject.com, 16356, RESELLER, 0bfd66d529a55807
+Axonix.com, 56266, RESELLER
+ironsrc.com, 211945, RESELLER, 79929e88b2ba73bc
+mintegral.com, 12101, RESELLER
+mobfox.com, 44666, RESELLER
+google.com, pub-8452579215562824, RESELLER, f08c47fec0942fa0
+google.com, pub-1467174215800884, RESELLER
+rubiconproject.com, 21604, RESELLER, 0bfd66d529a55807
+smartadserver.com, 1430, RESELLER
+smartadserver.com, 1289, RESELLER
+smartadserver.com, 3042, RESELLER
+tapjoy.com, a92a273e84854428a4d61a1867f58639, RESELLER, 29e595b1aeb5904d
+unity3d.com, 1019584, RESELLER, 96cabb5fbdde37a7
+telaria.com, rwd19-1019584, RESELLER, 1a4e959a1b50034a
+tremorhub.com, rwd19-1019584, RESELLER, 1a4e959a1b50034a
+loopme.com, 9621, RESELLER, 6c8d5f95897a5a3b
+adcolony.com, 0a0f72cd66122f31, RESELLER, 1ad675c9de6b5176
+pokkt.com, 6246, RESELLER, c45702d9311e25fd
+google.com, pub-6845454968529492, RESELLER
+google.com, pub-5253946476177754, RESELLER
+chartboost.com, 56e9877ff789823ee2a7e98f, RESELLER
+appnexus.com, 10005, RESELLER, f5ab79cb980f11d1
+indexexchange.com, 185578, RESELLER, 50b1c356f2c5c8fc
+lkqd.net, 459, RESELLER, 59c49fa9598a0117
+openx.com, 540338069, RESELLER, 6a698e2ec38604c6
+rhythmone.com, 1605779867, RESELLER, a670c89d4a324e47
+rubiconproject.com, 16834, RESELLER, 0bfd66d529a55807
+Vungle.com, 56f167bda94d7ae44a000103, RESELLER, c107d686becd2d77
+Openx.com, 540280728, RESELLER, 6a698e2ec38604c6
+Appnexus.com, 10128, RESELLER, f5ab79cb980f11d1
+Indexexchange.com, 185774, RESELLER, 50b1c356f2c5c8fc
+Inmobi.com, 2e0484e00bf84f35b133019004ef76a4, RESELLER, 83e75a7ae333ca9d
+Loopme.com, 10999, RESELLER, 6c8d5f95897a5a3b
+contextweb.com, 560288, RESELLER, 89ff185a4c4e857c
+pubmatic.com, 156439, RESELLER
+pubmatic.com, 154037, RESELLER
+pubmatic.com, 156030, RESELLER, 5d62403b186f2ace
+rubiconproject.com, 16114, RESELLER, 0bfd66d529a55807
+rubiconproject.com, 13132, RESELLER, 0bfd66d529a55807
+openx.com, 537149888, RESELLER, 6a698e2ec38604c6
+appnexus.com, 3703, RESELLER, f5ab79cb980f11d1
+groundtruth.com, 107, RESELLER, 81cbf0a75a5e0e9a
+districtm.io, 101760, RESELLER, 3fd707be9c4527c3
+loopme.com, s-2411, RESELLER, 6c8d5f95897a5a3b
+loopme.com, 5679, RESELLER, 6c8d5f95897a5a3b
+#Smaato
+smaato.com, 1100015281, RESELLER, 07bcf65f187117b4
+smaato.com, 1100042017, RESELLER, 07bcf65f187117b4
+smaato.com, 1100004890, RESELLER, 07bcf65f187117b4
+appnexus.com, 2764, RESELLER
+contextweb.com, 558622, RESELLER, 89ff185a4c4e857c
+groundtruth.com, 241, RESELLER, 81cbf0a75a5e0e9a
+indexexchange.com, 183920, RESELLER, 50b1c356f2c5c8fc
+indexexchange.com, 184270, RESELLER, 50b1c356f2c5c8fc
+openx.com, 540421297, RESELLER, 6a698e2ec38604c6
+pubmatic.com, 156177, RESELLER, 5d62403b186f2ace
+pubmatic.com, 156149, RESELLER, 5d62403b186f2ace
+smartadserver.com, 3117, RESELLER
+spotxchange.com, 140812, RESELLER, 7842df1d2fe2db34
+spotx.tv, 140812, RESELLER, 7842df1d2fe2db34
+#Tapjoy
+tapjoy.com, fdd0b892eac94dfa80d3b25b0ac52c44, RESELLER, 29e595b1aeb5904d
+rubiconproject.com, 12286, RESELLER, 0bfd66d529a55807
+#Vungle
+vungle.com, 561e8d956b8d90f61a003219, RESELLER, c107d686becd2d77
+adcolony.com, 1efc6603710003ea, RESELLER, 1ad675c9de6b5176
+appnexus.com, 10128, RESELLER, f5ab79cb980f11d1
+appnexus.com, 8178, RESELLER, f5ab79cb980f11d1
+contextweb.com, 561884, RESELLER, 89ff185a4c4e857c
+EMXDGT.com, 1324, RESELLER, 1e1d41537f7cad7f
+engagebdr.com, 10252, RESELLER
+improvedigital.com, 1366, RESELLER
+improvedigital.com, 1532, RESELLER
+indexexchange.com, 185774, RESELLER, 50b1c356f2c5c8fc
+loopme.com, 10999, RESELLER, 6c8d5f95897a5a3b
+openx.com, 537152826, RESELLER, 6a698e2ec38604c6
+openx.com, 539472296, RESELLER, 6a698e2ec38604c6
+openx.com, 540280728, RESELLER, 6a698e2ec38604c6
+openx.com, 540298543, RESELLER, 6a698e2ec38604c6
+pubmatic.com, 155975, RESELLER, 5d62403b186f2ace
+pubmatic.com, 158154, RESELLER, 5d62403b186f2ace
+pubnative.net, 1007302, RESELLER, d641df8625486a7b
+rhythmone.com, 4173858586, RESELLER, a670c89d4a324e47
+rubiconproject.com, 13626, RESELLER, 0bfd66d529a55807
+rubiconproject.com, 17328, RESELLER, 0bfd66d529a55807
+rubiconproject.com, 20744, RESELLER, 0bfd66d529a55807
+spotx.tv, 99441, RESELLER, 7842df1d2fe2db34
+spotxchange.com, 99441, RESELLER, 7842df1d2fe2db34
+#Unity
+unity3d.com, 1004715, RESELLER, 96cabb5fbdde37a7
+telaria.com, rwd19-1004715, RESELLER, 1a4e959a1b50034a
+tremorhub.com, rwd19-1004715, RESELLER, 1a4e959a1b50034a
+loopme.com, 9621, RESELLER, 6c8d5f95897a5a3b
+adcolony.com, 0a0f72cd66122f31, RESELLER, 1ad675c9de6b5176
+pokkt.com, 6246, RESELLER, c45702d9311e25fd
+google.com, pub-3259034378577333, RESELLER
+google.com, pub-1668617029356272, RESELLER
+google.com, pub-7955322303263231, RESELLER
+google.com, pub-8987504289926345, RESELLER
+#MyTarget
+target.my.com, 2301928, DIRECT
+admixer.com, 2301928, RESELLER
+pubmatic.com, 2301928, RESELLER
+onetag.com, 59d216e971852f2, RESELLER
+admixer.net, 2878f07c-cc3f-4f8a-a26c-8e6033a539a6, RESELLER
+betweendigital.com, 43092, RESELLER
+improvedigital.com, 1532, RESELLER
+lijit.com, 273644, RESELLER
+loopme.com, 11278, RESELLER
+onetag.com, 5d1628750185ace, RESELLER
+openx.com, 540298543, RESELLER
+openx.com, 541177349, RESELLER
+pubmatic.com, 158154, RESELLER
+pubmatic.com, 159542, RESELLER
+pubmatic.com, 159668, RESELLER
+rhythmone.com, 3880497124, RESELLER
+rubiconproject.com, 19724, RESELLER
+rubiconproject.com, 20744, RESELLER
+sovrn.com, 273644, RESELLER
+#Chartboost
+chartboost.com, 54b83545c909a62a7be7c075, RESELLER
+appnexus.com, 10005, RESELLER, f5ab79cb980f11d1
+indexexchange.com, 185578, RESELLER, 50b1c356f2c5c8fc
+lkqd.net, 459, RESELLER, 59c49fa9598a0117
+openx.com, 540338069, RESELLER, 6a698e2ec38604c6
+rubiconproject.com, 16834, RESELLER, 0bfd66d529a55807
+#OpenX
+openx.com, 540396775, RESELLER, 6a698e2ec38604c6
+#Pubmatic
+Pubmatic.com, 157800, RESELLER, 5d62403b186f2ace
+Pubmatic.com, 158118, RESELLER, 5d62403b186f2ace
+#Rubicon
+rubiconproject.com, 18364, RESELLER, 0bfd66d529a55807
+#Axonix
+axonix.com, 57311, RESELLER
+#Pubnative
+improvedigital.com, 1150, RESELLER
+improvedigital.com, 1751, RESELLER
+aol.com, 57992, RESELLER, e1a5b5b6e3255540
+yahoo.com, 57992, RESELLER, e1a5b5b6e3255540
+tpmn.io 256, RESELLER
+mars.media, 1010380, RESELLER, 8624339f102fb076
+Pubnative.net, 1007063, RESELLER, d641df8625486a7b
+Pubnative.net, 1003601, RESELLER, d641df8625486a7b
+pubmatic.com, 160145, RESELLER, 5d62403b186f2ace
+appnexus.com, 8178, RESELLER, f5ab79cb980f11d1
+rubiconproject.com, 17328, RESELLER, 0bfd66d529a55807
+adcolony.com, 1efc6603710003ea, RESELLER, 1ad675c9de6b5176
+rhythmone.com, 4173858586, RESELLER, a670c89d4a324e47
+engagebdr.com, 10252, RESELLER #banner #video
+bidmachine.io, 55, RESELLER
+bidmachine.io, 59, RESELLER
+bidmachine.io, 138, RESELLER
+inmobi.com, f3924290136e4129a5c082ff982c3a58, RESELLER, 83e75a7ae333ca9d
+Verve.com, 15503, RESELLER, 0c8f5958fc2d6270 #Verve
+Rubiconproject.com, 15278, RESELLER, 0bfd66d529a55807 #Verve
+Inmobi.com, c1e6d3502da64ebaa3ad0e4a4be15f11, RESELLER, 83e75a7ae333ca9d #Verve
+Pubmatic.com, 156517, RESELLER, 5d62403b186f2ace #Verve
+Sabio.us, 100032, RESELLER, 96ed93aaa9795702 #Verve
+openx.com, 540543195, RESELLER, 6a698e2ec38604c6 #Verve
+Contextweb.com, 561849, RESELLER, 89ff185a4c4e857c #Verve
+indexexchange.com, 192829, RESELLER, 50b1c356f2c5c8fc #Verve
+indexexchange.com, 191332, RESELLER, 50b1c356f2c5c8fc
+admixer.net, 8e380da6-31ba-488c-939c-290c48d577e4, RESELLER
+onetag.com, 59aa7be4921bac8, RESELLER
+advertising.com, 28246, RESELLER
+sonobi.com, eaec54c63f, RESELLER, d1a215d9eb5aee9e
+improvedigital.com, 1210, RESELLER
+loopme.com, 11322, RESELLER, 6c8d5f95897a5a3b
+rubiconproject.com, 20744, RESELLER, 0bfd66d529a55807
+openx.com, 540298543, RESELLER, 6a698e2ec38604c6
+lkqd.net, 647, RESELLER, 59c49fa9598a0117
+lkqd.net, 654, RESELLER, 59c49fa9598a0117
+advertising.com, 24315, RESELLER
+beachfront.com, 7300, RESELLER
+tappx.com, 36788, RESELLER, 9f375a07da0318ec
+pubmatic.com, 92509, RESELLER, 5d62403b186f2ace
+smartadserver.com, 1692, RESELLER
+rubiconproject.com, 13856, RESELLER, 0bfd66d529a55807
+adcolony.com, c490f6e7399a25d6, RESELLER, 1ad675c9de6b5176
+appnexus.com, 9569, RESELLER
+inmobi.com, ec6f6ceb8bb1440ba5455644ec96c275, RESELLER, 83e75a7ae333ca9d
+verve.com, 15624, RESELLER, 0c8f5958fc2d6270
+appnexus.com, 10617, RESELLER, f5ab79cb980f11d1
+#GroundTruth
+xad.com, 950, RESELLER, 81cbf0a75a5e0e9a
+rubiconproject.com, 13132, RESELLER, 0bfd66d529a55807
+#Liftoff
+liftoff.io, 7f6945815e6, RESELLER
+#Mintegral
+mintegral.com, 6028, RESELLER
+#AdColony
+adcolony.com, a038eff5729c4315, RESELLER, 1ad675c9de6b5176
+adcolony.com, 5d8cbf6671c93a42, RESELLER, 1ad675c9de6b5176
+adcolony.com, 0a0f72cd66122f31, RESELLER, 1ad675c9de6b5176
+adcolony.com, 1efc6603710003ea, RESELLER, 1ad675c9de6b5176
+adcolony.com, a038eff5729c4315, RESELLER, 1ad675c9de6b5176
+adcolony.com, c490f6e7399a25d6, RESELLER, 1ad675c9de6b5176
+adcolony.com, b3acb7d4c1dd14e9, RESELLER, 1ad675c9de6b5176
+pubnative.net, 1007112, RESELLER, d641df8625486a7b
+pubnative.net, 1005686, RESELLER, d641df8625486a7b
+peak226.com, 12920, RESELLER
+peak226.com, 12921, RESELLER
+appnexus.com, 3756, RESELLER, f5ab79cb980f11d1
+betweendigital.com, 43956, RESELLER
+#Epom
+epom.com, 4d27017f-f425-44a0-a30b-e9ec69f8bba8, RESELLER
+admanmedia.com, 543, RESELLER
+yahoo.com,1662359, RESELLER
+ucfunnel.com, par-2EDDB423AA24474188B843EE4842932, RESELLER
+newborntown.com, R_1039 ,RESELLER
+#Tappx
+tappx.com, 33312, DIRECT, 9f375a07da0318ec
+tappx.com, 32425, DIRECT, 9f375a07da0318ec
+pubmatic.com, 92509, RESELLER, 5d62403b186f2ace
+groundtruth.com, 107, RESELLER, 81cbf0a75a5e0e9a
+smartadserver.com, 1692, RESELLER
+rubiconproject.com, 13856, RESELLER, 0bfd66d529a55807
+adcolony.com, c490f6e7399a25d6, RESELLER, 1ad675c9de6b5176
+loopme.com, 11227, RESELLER, 6c8d5f95897a5a3b
+appnexus.com, 9569, RESELLER
+appnexus.com, 2928, RESELLER
+appnexus.com, 8233, RESELLER
+pubmatic.com, 156538, RESELLER, 5d62403b186f2ace
+pubmatic.com, 81564, RESELLER, 5d62403b186f2ace
+richaudience.com, skJudSCZ30, RESELLER
+rubiconproject.com, 13510, RESELLER
+pubmatic.com, 158111, RESELLER, 5d62403b186f2ace
+appnexus.com, 10824, RESELLER
+indexexchange.com, 193880, RESELLER
+chartboost.com, 5da62a1035b91e0aff190bf7, RESELLER
+inmobi.com, ec6f6ceb8bb1440ba5455644ec96c275, RESELLER, 83e75a7ae333ca9d
+telaria.com, s92od-u4sw5, RESELLER, 1a4e959a1b50034a
+tremorhub.com, s92od-u4sw5, RESELLER, 1a4e959a1b50034a
+#IndexExchange
+indexexchange.com, 186081, Reseller
+#Chartboost
+chartboost.com, 5d55f702facb6743686c50cc, DIRECT
+appnexus.com, 10005, RESELLER, f5ab79cb980f11d1
+bidmachine.io, 98, RESELLER
+gothamads.com, 532, RESELLER, d9c86e5dec870222
+gothamads.com, 533, RESELLER, d9c86e5dec870222
+indexexchange.com, 185578, RESELLER, 50b1c356f2c5c8fc
+lkqd.net, 459, RESELLER, 59c49fa9598a0117
+mobfox.com, 82593, RESELLER, 5529a3d1f59865be
+openx.com, 540338069, RESELLER, 6a698e2ec38604c6
+rhythmone.com, 1605779867, RESELLER, a670c89d4a324e47
+rubiconproject.com, 16834, RESELLER, 0bfd66d529a55807
+lunamedia.io, 193bca549318aed0434226d4d73e13f3, RESELLER,524ecb396915caaf
+themediagrid.com, R28I9J, RESELLER, 35d5010d7789b49d
+advertising.com, 28734, RESELLER
+spotxchange.com, 295535, RESELLER, 7842df1d2fe2db34
+spotx.tv, 295535, RESELLER, 7842df1d2fe2db34
+improvedigital.com, 1720, RESELLER
+pubnative.net, 1007485, RESELLER, d641df8625486a7b
+verve.com, 15503, RESELLER, 0c8f5958fc2d6270
+pubmatic.com, 155975, RESELLER, 5d62403b186f2ace
+pubmatic.com, 156517, RESELLER, 5d62403b186f2ace
+adcolony.com, 1efc6603710003ea, RESELLER, 1ad675c9de6b5176
+improvedigital.com, 1366, RESELLER
+engagebdr.com, 10252, RESELLER
+inmobi.com, f3924290136e4129a5c082ff982c3a58, RESELLER,83e75a7ae333ca9d
+inmobi.com, c1e6d3502da64ebaa3ad0e4a4be15f11, RESELLER,83e75a7ae333ca9d
+sabio.us, 100032, RESELLER, 96ed93aaa9795702
+contextweb.com, 561849, RESELLER, 89ff185a4c4e857c
+spotxchange.com, 234183, RESELLER, 7842df1d2fe2db34
+spotx.tv, 234183, RESELLER, 7842df1d2fe2db34
+admixer.net, 8e380da6-31ba-488c-939c-290c48d577e4, RESELLER
+onetag.com, 59aa7be4921bac8, RESELLER
+advertising.com, 28246, RESELLER
+sonobi.com, eaec54c63f, RESELLER, d1a215d9eb5aee9e
+video.unrulymedia.com, 1605779867, RESELLER
+lunamedia.io, 193bca549318aed0434226d4d73e13f3, RESELLER,524ecb396915caaf
+themediagrid.com, R28I9J, RESELLER, 35d5010d7789b49d
+pubmatic.com, 160492, RESELLER, 5d62403b186f2ace
+pubmatic.com, 160493, RESELLER, 5d62403b186f2ace
+loopme.com, 11367, RESELLER, 6c8d5f95897a5a3b
+meitu.com, 621, RESELLER
+algorix.co, 60055, RESELLER, 5b394c12fea27a1d
+admixer.net, 75e4a586-442d-47c3-ac85-0b5b00547cdd, RESELLER
+tappx.com, 36909, RESELLER, 9f375a07da0318ec
+pubmatic.com, 92509, RESELLER, 5d62403b186f2ace
+groundtruth.com, 107, RESELLER, 81cbf0a75a5e0e9a
+smartadserver.com, 1692, RESELLER
+adcolony.com, c490f6e7399a25d6, RESELLER, 1ad675c9de6b5176
+#Algorix
+algorix.co, 54821, DIRECT, 5b394c12fea27a1d
+algorix.co, 60085, DIRECT, 5b394c12fea27a1d
+algorix.co, 60086, DIRECT, 5b394c12fea27a1d
+algorix.co, 60088, DIRECT, 5b394c12fea27a1d
+algorix.co, 60098, DIRECT, 5b394c12fea27a1d
+algorix.co, 60105, DIRECT, 5b394c12fea27a1d
+algorix.co, 60113, DIRECT, 5b394c12fea27a1d
+algorix.co, 60110, DIRECT, 5b394c12fea27a1d
+algorix.co, 60109, DIRECT, 5b394c12fea27a1d
+algorix.co, 60106, DIRECT, 5b394c12fea27a1d
+algorix.co, 60112, DIRECT, 5b394c12fea27a1d
+algorix.co, 60111, DIRECT, 5b394c12fea27a1d
+algorix.co, 60112, DIRECT, 5b394c12fea27a1d
+ucfunnel.com, par-9A292743382DDA3AC4B7964D293EBE44, reseller
+ucfunnel.com, par-BE7E29B3B48DE66BC7DDDA24E6267E29, reseller
+aralego.com, par-9A292743382DDA3AC4B7964D293EBE44, reseller
+aralego.com, par-BE7E29B3B48DE66BC7DDDA24E6267E29, reseller
+openx.com, 540838151, RESELLER, 6a698e2ec38604c6
+inmobi.com, 22e5354e453f49348325184e25464adb, RESELLER, 83e75a7ae333ca9d
+improvedigital.com, 1849, RESELLER
+Peak226.com, 12900, RESELLER
+Peak226.com, 12901, RESELLER
+engagebdr.com, 10423, RESELLER
+indexexchange.com, 192143, RESELLER
+ninthdecimal.com, 1c383cd30b7c298ab50293adfecb7b18, RESELLER, 3aff2148687b274b
+rubiconproject.com, 17328, RESELLER, 0bfd66d529a55807
+olaex.biz,100039, RESELLER
+smartadserver.com, 3817, RESELLER
+Eskimi.com, eas-2020000003, RESELLER
+admixer.net, a80e4ca1-f52f-4aa5-98e1-010c8d08251b, RESELLER
+Pubmatic.com, 157800, RESELLER, 5d62403b186f2ace
+onetag.com, 5a02ff98ba6be67, RESELLER
+advertising.com, 28246, RESELLER
+mobuppsrtb.com, 68264bdb65b97eeae6788aa3348e553c, RESELLER
+decenterads.com, 408, RESELLER
+#SmartyAds
+smartyads.com, 1369, RESELLER, fd2bde0ff2e62c5d
+improvedigital.com, 1057, RESELLER
+peak226.com, 12400, RESELLER
+cmcm.com, 104, RESELLER
+cmcm.com, 72, RESELLER
+webeyemob.com, 70085, RESELLER
+bizzclick.com, 53, RESELLER, 7e936b1feafdaa61
+bizzclick.com, 39, RESELLER, 7e936b1feafdaa61
+bizzclick.com, 1, RESELLER, 7e936b1feafdaa61
+bizzclick.com, 28, RESELLER, 7e936b1feafdaa61
+bizzclick.com, 30, RESELLER, 7e936b1feafdaa61
+google.com, pub-3805568091292313, RESELLER, f08c47fec0942fa0
+freewheel.tv, 30189, RESELLER
+freewheel.tv, 64289, RESELLER
+www.spotx.tv, 78856, RESELLER
+smartyads.com, 355, DIRECT, fd2bde0ff2e62c5d
+quantumdex.io, EXU5919, RESELLER
+ssp.e-volution.ai, AJxF6R108a9M6CaTvK, RESELLER
+themediagrid.com, R28I9J, RESELLER, 35d5010d7789b49d
+betweendigital.com, 43092, RESELLER
+improvedigital.com, 1797, RESELLER
+ssp.logan.ai, AJxF6R2a9M6CaTvK, RESELLER
+ssp.e-volution.ai, AJxF6R108a9M6CaTvK, RESELLER
+freewheel.tv, 1192767, RESELLER
+freewheel.tv, 1192799, RESELLER
+betweendigital.com, 43092, RESELLER
+advertising.com, 28734, RESELLER
+#Mobfox
+appnexus.com,2637,RESELLER,f5ab79cb980f11d1
+appnexus.com,2850,RESELLER,f5ab79cb980f11d1
+xad.com,589,RESELLER,81cbf0a75a5e0e9a
+inmobi.com,a5e661acdc384e91a79a58eb3418e99f,RESELLER,83e75a7ae333ca9d
+#AdMixer
+admixer.net, 6477248d-9798-4581-9bfd-2e83e6d35cd3, RESELLER
+inmobi.com, 61d733c3779d43e590c51c8bc078e10c, RESELLER, 83e75a7ae333ca9d
+e-planning.net,ec771b05828a67fa,RESELLER,c1ba615865ed87b2
+improvedigital.com,1556,RESELLER
+onetag.com, 59d216e971852f2, RESELLER
+#Silvermob
+silvermob.com,419,RESELLER
+#LoopMe
+loopme.com, 11347, DIRECT, 6c8d5f95897a5a3b
+rubiconproject.com, 20744, RESELLER, 0bfd66d529a55807
+penx.com, 540298543, RESELLER, 6a698e2ec38604c6
+#MarsMedia
+mars.media, 1010421, DIRECT, 8624339f102fb076
+advertising.com, 6814, RESELLER
+beachfront.com, 805, RESELLER, e2541279e8e2ca4d
+improvedigital.com, 1221, RESELLER
+onetag.com, 5e18052625cfd00, RESELLER
+appnexus.com, 12223, RESELLER, f5ab79cb980f11d1
+freewheel.tv, 1161393, RESELLER
+pubmatic.com, 160195, RESELLER, 5d62403b186f2ace
+pubmatic.com, 160194, RESELLER, 5d62403b186f2ace
+freewheel.tv, 1162449, RESELLER
+gitberry.com, 3OJ, RESELLER
+improvedigital.com, 1662, RESELLER
+smartadserver.com, 4039, RESELLER
+appnexus.com, 2579, RESELLER, f5ab79cb980f11d1
+#EngageBDR
+engagebdr.com, 10073, RESELLER
+#Brave
+appnexus.com, 12061, RESELLER, f5ab79cb980f11d1
+appnexus.com, 12501 , RESELLER, f5ab79cb980f11d1
+thebrave.io, 9840732, DIRECT, c25b2154543746ac
+supply.colossusssp.com, 244, RESELLER, 6c5b49d96ec1b458
+smartadserver.com, 3964, RESELLER
+indexexchange.com, 192585, RESELLER
+onetag.com, 5fc7cb4d7816390, RESELLER
+appnexus.com, 12878, RESELLER, f5ab79cb980f11d1
+betweendigital.com, 43989, RESELLER
+adsparc, 986, RESELLER
+google.com, pub-5289985627731322, RESELLER, f08c47fec0942fa0
+sovrn.com, 273644, RESELLER, fafdf38b16bf6b2b
+lijit.com, 273644, RESELLER, fafdf38b16bf6b2b
+improvedigital.com, 1461, RESELLER
+smartadserver.com, 3503, RESELLER
+freewheel.tv, 1106481, RESELLER
+#Unruly
+rhythmone.com, 3634565696, DIRECT, a670c89d4a324e47
+video.unrulymedia.com, 3634565696, DIRECT
+indexexchange.com, 182257, RESELLER
+appnexus.com, 6849, RESELLER
+rubiconproject.com, 15268, RESELLER
+spotxchange.com, 285547, RESELLER, 7842df1d2fe2db34
+spotx.tv, 285547, RESELLER, 7842df1d2fe2db34
+pubmatic.com, 159277, RESELLER, 5d62403b186f2ace
+advertising.com, 28605, RESELLER
+improvedigital.com, 1699, RESELLER
+#Adview
+adview.com, 48045325, DIRECT, 1b2cc038a11ea319
+pubwheel.com, 48045325, DIRECT, 1b2cc038a11ea319
+admanmedia.com, 48, RESELLER
+admixer.co.kr, 1287, RESELLER
+admixer.net, 0072fb58-999b-445e-9a9b-3fc2a7194277, RESELLER
+admixer.net, de2ae535-59eb-4f0b-95e3-89f821933d47, RESELLER
+advertising.com, 25990, RESELLER
+appnexus.com, 10005, RESELLER, f5ab79cb980f11d1
+appnexus.com, 10824, RESELLER,f5ab79cb980f11d1
+Appnexus.com, 8178, RESELLER, f5ab79cb980f11d1
+appnexus.com, 9569, RESELLER,f5ab79cb980f11d1
+appnexus.com, 4052, RESELLER,f5ab79cb980f11d1
+appnexus.com, 3703, RESELLER, f5ab79cb980f11d1
+aralego.com, par-BE776B39322A364BC7767A69AB99BBD9, RESELLER
+aralego.com, par-D233672DD744287DCD7E2439B82494AD, RESELLER
+contextweb.com, 562122, RESELLER, 89ff185a4c4e857c
+conversantmedia.com, 100081, RESELLER, 03113cd04947736d
+decenterads.com, 14, RESELLER
+decenterads.com, 92, RESELLER
+districtm.io,101649,RESELLER,3fd707be9c4527c3
+EMXDGT.com, 1324, RESELLER, 1e1d41537f7cad7f
+gammassp.com, 1521707344, RESELLER, 31ac53fec2772a83
+google.com, pub-9685734445476814, RESELLER, f08c47fec0942fa0
+groundtruth.com, 107, RESELLER, 81cbf0a75a5e0e9a
+improvedigital.com, 1331, RESELLER
+indexexchange.com, 185578, RESELLER, 50b1c356f2c5c8fc
+inmobi.com, 867c89bb53994aaeb9dae3ce75b03e78, RESELLER, 83e75a7ae333ca9d
+lkqd.net, 459, RESELLER, 59c49fa9598a0117
+pokkt.com, 7000, RESELLER, c45702d9311e25fd
+smartadserver.com, 3797, RESELLER
+smartadserver.com, 1692, RESELLER
+smartyads.com, 368, RESELLER
+spotx.tv, 117872, RESELLER, 7842df1d2fe2db34
+spotx.tv, 283422, RESELLER, 7842df1d2fe2db34
+spotxchange.com, 117872, RESELLER, 7842df1d2fe2db34
+spotxchange.com, 283422, RESELLER, 7842df1d2fe2db34
+telaria.com, s92od-u4sw5, RESELLER, 1a4e959a1b50034a
+tremorhub.com, s92od-u4sw5, RESELLER, 1a4e959a1b50034a
+Verve.com, 15290, RESELLER, 0c8f5958fc2d6270
+#Prequel.tv
+improvedigital.com, 1880, RESELLER
+appnexus.com, 12501, RESELLER
+improvedigital.com, 1786, RESELLER
+prequel.tv,513,RESELLER
+improvedigital.com, 1772, RESELLER
+beachfront.com, 7300, RESELLER
+improvedigital.com, 1751, RESELLER
+freewheel.tv, 1201999, RESELLER
+#Lunamedia
+lunamedia.io, 3b6479612cc0834068fdd8a2e52b8dc6, DIRECT, 524ecb396915caaf
+xandr.com, 12745, DIRECT, f5ab79cb980f11d1
+indexexchange.com, 194301, RESELLER, 50b1c356f2c5c8f
+themediagrid.com, R28I9J, DIRECT, 35d5010d7789b49d
+Contextweb.com, 558752, RESELLER, 89ff185a4c4e857c
+meitu.com, 621, DIRECT
+cmcm.com, 127, RESELLER
+appnexus.com, 8217, RESELLER, f5ab79cb980f11d1
+betweendigital.com, 43916, DIRECT
+betweendigital.com, 43092, RESELLER
+google.com, pub-5289985627731322, RESELLER, f08c47fec0942fa0
+xandr.com, 12745, DIRECT, f5ab79cb980f11d1
+google.com, pub-4836542095728076, DIRECT, f08c47fec0942fa0
+#Decenterads
+adcolony.com, e8d70ef9dfabde92, RESELLER, 1ad675c9de6b5176
+e-planning.net,d2037ff5e86495fd,RESELLER,c1ba615865ed87b2
+aol.com, 57992, RESELLER, e1a5b5b6e3255540
+Yahoo.com, 57992, RESELLER, e1a5b5b6e3255540
+e-planning.net,f063f576aa383fc1,RESELLER,c1ba615865ed87b2
+indexexchange.com,190243,RESELLER
+richaudience.com,25BiP9IMgN,RESELLER
+advertising.com,7574,RESELLER
+appnexus.com,8233,RESELLER
+entravision.com, 000713, RESELLER
+bidscube.com, 28, RESELLER
+adsgard.net, 2, RESELLER
+decenterads.com, 996, DIRECT
+improvedigital.com, 1880, RESELLER
+appnexus.com, 12752, RESELLER
+improvedigital.com, 1751, RESELLER
+beachfront.com, 7300, RESELLER
+improvedigital.com, 1786, RESELLER
+advertising.com, 24315, RESELLER
+#AdElement
+adelement.com, 101, DIRECT
+freewheel.tv, 1199791, RESELLER
+freewheel.tv, 1199807, RESELLER
+freewheel.tv, 1199631, RESELLER
+freewheel.tv, 1199647, RESELLER
+onetag.com, 6d9d434caf08ff8, DIRECT
+yahoo.com, 57490, RESELLER
+advertising.com, 28886, RESELLER
+nobid.io, 22344102582, DIRECT
+#AcuityAds
+admanmedia.com, 613, DIRECT
+xandr.com, 8804, RESELLER, f5ab79cb980f11d1
+indexexchange.com, 191497, RESELLER
+smartadserver.com, 3713, RESELLER
+sonobi.com, 7b37f8ccbc, RESELLER, d1a215d9eb5aee9e
+inmobi.com, 3a4f7da341dd490cbb7dde02b126275e, RESELLER, 83e75a7ae333ca9d
+adform.com, 2671, RESELLER
+#Se7en DSP
+smartadserver.com, 3964, DIRECT
+teads.tv, 21703, DIRECT, 15a9c44f6d26cbe1
+contextweb.com, 560288, RESELLER, 89ff185a4c4e857c
+appnexus.com, 3703, RESELLER, f5ab79cb980f11d1
+xad.com, 958, RESELLER, 81cbf0a75a5e0e9a
+smaato.com, 1100044045, RESELLER, 07bcf65f187117b4
+adyoulike.com, b4bf4fdd9b0b915f746f6747ff432bde, RESELLER
+admanmedia.com, 43, RESELLER
+#Hax Media Partners
+haxmediapartners.com, AJxF6R124a9M6CaTvK, RESELLER
+betweendigital.com, 43743, RESELLER
+Eskimi.com, eas-2020000007, RESELLER
+nobid.io, 22317445395, RESELLER
+onetag.com, 6edfae7c05e75eb, RESELLER
+rhythmone.com, 1295892552, RESELLER, a670c89d4a324e47
+video.unrulymedia.com, 1295892552, RESELLER
+entravision.com, 000713, RESELLER
+algorix.co, 60163, RESELLER, 5b394c12fea27a2d
+bidscube.com, 28, RESELLER
+adsgard.net, 2, RESELLER
+decenterads.com, 996, DIRECT
+#AdElement
+adelement.com, 101, DIRECT
+pubmatic.com, 156855, DIRECT, 5d62403b186f2ace
+pubmatic.com, 157558, RESELLER, 5d62403b186f2ace
+pubmatic.com, 158362, RESELLER, 5d62403b186f2ace
+freewheel.tv, 1199791, RESELLER
+freewheel.tv, 1199807, RESELLER
+freewheel.tv, 1199631, RESELLER
+freewheel.tv, 1199647, RESELLER
+onetag.com, 6d9d434caf08ff8, DIRECT
+yahoo.com, 57490, DIRECT
+advertising.com, 28886, DIRECT
+#Hax Media Partners
+haxmediapartners.com, AJxF6R124a9M6CaTvK, RESELLER
+betweendigital.com, 43743, RESELLER
+Eskimi.com, eas-2020000007, RESELLER
+nobid.io, 22317445395, RESELLER
+onetag.com, 6edfae7c05e75eb, RESELLER
+#Brightcom DSP
+brightcom.com, 15800, DIRECT
+appnexus.com, 12695, RESELLER, f5ab79cb980f11d1
+improvedigital.com, 1231, RESELLER
+improvedigital.com, 1893, RESELLER
+improvedigital.com, 1698, RESELLER
+supply.colossusssp.com, 196, DIRECT, 6c5b49d96ec1b458

--- a/packages/algorithm/test/algorithm_test.dart
+++ b/packages/algorithm/test/algorithm_test.dart
@@ -1,6 +1,5 @@
 import 'package:base/prophecy/entity/prophecy.dart';
 import 'package:base/user/entity/user.dart';
-import 'package:base/user/repository/flutter_default/flutter_default.dart';
 import 'package:algorithm/algorithm.dart';
 import 'package:test/test.dart';
 

--- a/packages/mobile_app/android/app/build.gradle
+++ b/packages/mobile_app/android/app/build.gradle
@@ -34,7 +34,7 @@ if (keystorePropertiesFile.exists()) {
 }
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 31
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
@@ -46,8 +46,8 @@ android {
 
     defaultConfig {
         applicationId "app.myprophet"
-        minSdkVersion 19
-        targetSdkVersion 29
+        minSdkVersion 21
+        targetSdkVersion 31
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         multiDexEnabled true

--- a/packages/mobile_app/android/app/src/main/AndroidManifest.xml
+++ b/packages/mobile_app/android/app/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
          In most cases you can leave this as-is, but you if you want to provide
          additional functionality it is fine to subclass or reimplement
          FlutterApplication and put your custom class here. -->
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <application
         android:name="io.flutter.app.FlutterApplication"
         android:label="@string/app_name"
@@ -44,8 +45,9 @@
         <meta-data
             android:name="flutterEmbedding"
             android:value="2" />
+        <!-- stub ID is used here because of appodeal, see https://pub.dev/packages/appodeal_flutter -->
         <meta-data
             android:name="com.google.android.gms.ads.APPLICATION_ID"
-            android:value="ca-app-pub-6881469170510700~7333477499"/>
+            android:value="ca-app-pub-0000000000000000~0000000000"/>
     </application>
 </manifest>

--- a/packages/mobile_app/android/build.gradle
+++ b/packages/mobile_app/android/build.gradle
@@ -8,8 +8,8 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:4.1.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath 'com.google.gms:google-services:4.3.8'
-        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.7.0'
+        classpath 'com.google.gms:google-services:4.3.10'
+        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.7.1'
     }
 }
 

--- a/packages/mobile_app/ios/Runner/Info.plist
+++ b/packages/mobile_app/ios/Runner/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 	<dict>
 		<key>GADApplicationIdentifier</key>
-		<string>ca-app-pub-6881469170510700~7333477499</string>
+		<string>ca-app-pub-0000000000000000~0000000000</string>
 		<key>SKAdNetworkItems</key>
 		<array>
 			<dict>

--- a/packages/mobile_app/lib/app_global.dart
+++ b/packages/mobile_app/lib/app_global.dart
@@ -8,9 +8,9 @@ import 'package:base/user/repository/interface.dart';
 import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/foundation.dart';
-import 'package:google_mobile_ads/google_mobile_ads.dart';
 import 'package:mutable_wrappers/mutable_wrappers.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'logic/ads.dart';
 import 'logic/localization/predictions.dart';
 
 export 'package:base/preferences/interface.dart';
@@ -68,9 +68,11 @@ class _Firebase {
 }
 
 class _Ads {
-  AdManagerInterstitialAd manager;
   bool adsWatched = false;
-  bool adsLoaded = false;
+  bool adsLoaded = true;
+  bool adsConsentGiven = false;
+  bool adsConsentNeeded = false;
+  AdsManager manager;
 }
 
 class _LocalNotifications {

--- a/packages/mobile_app/lib/index.dart
+++ b/packages/mobile_app/lib/index.dart
@@ -5,7 +5,6 @@ export 'package:firebase_core/firebase_core.dart';
 export 'package:firebase_messaging/firebase_messaging.dart';
 export 'package:flutter/material.dart';
 export 'package:flutter_dotenv/flutter_dotenv.dart';
-export 'package:google_mobile_ads/google_mobile_ads.dart';
 export 'package:algorithm/algorithm.dart';
 export 'package:my_horoskope/app_global.dart';
 export 'package:my_horoskope/common/precache_assets.dart';

--- a/packages/mobile_app/lib/main.dart
+++ b/packages/mobile_app/lib/main.dart
@@ -40,10 +40,8 @@ void main() async {
   }
 
   /// ads
-  MobileAds.instance.initialize();
-  initAds(onLoaded: (manager) {
+  initAds(onLoaded: () {
     AppGlobal.ads.adsLoaded = true;
-    AppGlobal.ads.manager = manager;
   }, onWatched: () {
     AppGlobal.ads.adsWatched = true;
   }, onFailed: (error) {

--- a/packages/mobile_app/pubspec.lock
+++ b/packages/mobile_app/pubspec.lock
@@ -8,6 +8,13 @@ packages:
       relative: true
     source: path
     version: "0.0.1+1"
+  appodeal_flutter:
+    dependency: "direct main"
+    description:
+      name: appodeal_flutter
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.1"
   archive:
     dependency: transitive
     description:
@@ -270,13 +277,6 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  google_mobile_ads:
-    dependency: "direct main"
-    description:
-      name: google_mobile_ads
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.13.3"
   http:
     dependency: transitive
     description:

--- a/packages/mobile_app/pubspec.yaml
+++ b/packages/mobile_app/pubspec.yaml
@@ -1,6 +1,6 @@
 name: my_horoskope
 description: Your personal prophet
-homepage: prophet.ninja
+homepage: myhoroskope.app
 publish_to: none
 version: 0.5.59
 
@@ -45,7 +45,9 @@ dependencies:
   firebase_core: ^1.4.0
   firebase_analytics: ^8.2.0
   firebase_crashlytics: ^2.1.1
-  google_mobile_ads: ^0.13.3
+
+  # ads
+  appodeal_flutter: ^1.1.1
 
   # not used
   firebase_in_app_messaging: any 


### PR DESCRIPTION
In order to be consistent with GDPR and other data privacy protection laws,
we need to ask user for a permission to use their ad tracking id.

Some of the ad networks implemented such dialogs.
We are using one from Appodeal.

We ask the permission namely when the user has clicked over four cards and ready to see the ads.
Then we ash the user to give consent and show the "Give consent" button.

![consent button](https://user-images.githubusercontent.com/1504642/133945316-73a18af0-aa66-404b-b93e-42ec69b2f354.png)

This commit also contains Appodeal SDK integration.

What has been added:
* actualized `app-ads.txt`
* added localizations for the user consent
* android SDK version updated to 21 (requirement of Appodeal)
* removed `google_admob` and its id from the manifest